### PR TITLE
fix: Server | swagger 서버 url 변경

### DIFF
--- a/Backend/sdutyplus/src/main/java/com/d205/sdutyplus/global/config/SwaggerConfig.java
+++ b/Backend/sdutyplus/src/main/java/com/d205/sdutyplus/global/config/SwaggerConfig.java
@@ -48,7 +48,7 @@ public class SwaggerConfig {
                 .build();
 
         Server serverLocal = new Server("local", "http://localhost:8090", "for local usages", Collections.emptyList(), Collections.emptyList());
-        Server testServer = new Server("test", "https://d205.kro.kr/api", "for testing", Collections.emptyList(), Collections.emptyList());
+        Server testServer = new Server("test", "https://sp205.kro.kr/api", "for testing", Collections.emptyList(), Collections.emptyList());
 
         return new Docket(DocumentationType.OAS_30).apiInfo(apiInfo)
                 .alternateTypeRules(AlternateTypeRules


### PR DESCRIPTION
서버 도메인 유효기간 만료로 인한 서버 URL변경