### PR TITLE
Backend

### DIFF
--- a/Backend/sdutyplus/src/main/java/com/d205/sdutyplus/domain/user/controller/UserAuthController.java
+++ b/Backend/sdutyplus/src/main/java/com/d205/sdutyplus/domain/user/controller/UserAuthController.java
@@ -12,6 +12,7 @@ import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -67,8 +68,13 @@ public class UserAuthController {
         return ResponseEntity.ok(ResponseDto.of(ResponseCode.LOGIN_FAIL));
     }
 
+    @ApiOperation(value="테스트 계정 로그인")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "U001 - 로그인에 성공하였습니다."),
+            @ApiResponse(code = 401, message = "U005 - 계정 정보가 일치하지 않습니다.")
+    })
     @PostMapping("/test/login")
-    public ResponseEntity<ResponseDto> testLogin(){
+    public synchronized ResponseEntity<ResponseDto> testLogin(){
         final UserLoginDto userLoginDto = userAuthService.loginTestUser();
         return ResponseEntity.ok(ResponseDto.of(ResponseCode.LOGIN_SUCCESS, userLoginDto));
     }
@@ -92,7 +98,6 @@ public class UserAuthController {
     public ResponseEntity<ResponseDto> deleteUser(){
 
         boolean success = userAuthService.deleteUser();
-        log.info("회원탈퇴 "+success);
         if (success) {
             return ResponseEntity.ok(ResponseDto.of(ResponseCode.DELETE_SUCCESS));
         } else {

--- a/Backend/sdutyplus/src/test/java/com/d205/sdutyplus/user/UserTestLoginTest.java
+++ b/Backend/sdutyplus/src/test/java/com/d205/sdutyplus/user/UserTestLoginTest.java
@@ -1,24 +1,41 @@
 package com.d205.sdutyplus.user;
 
+import com.d205.sdutyplus.domain.user.controller.UserAuthController;
+import com.d205.sdutyplus.domain.user.dto.UserLoginDto;
+import com.d205.sdutyplus.domain.user.service.UserAuthService;
+import com.d205.sdutyplus.global.response.ResponseDto;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static com.d205.sdutyplus.domain.user.entity.QUser.user;
 import static com.d205.sdutyplus.domain.user.entity.SocialType.SDUTY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @SpringBootTest
 public class UserTestLoginTest {
 
     @Autowired
     private JPAQueryFactory queryFactory;
+    @Autowired
+    private UserAuthService userAuthService;
+    @Autowired
+    private UserAuthController userAuthController;
 
     @Test
+    @Transactional
     @DisplayName("테스트용 계정 생성 테스트")
     public void makeTestIDTest(){
         List<String> testUsers = getLastUserID();
@@ -41,6 +58,39 @@ public class UserTestLoginTest {
         }
 
     }
+    
+//    @Test
+//    @DisplayName("테스트 로그인 중복 요청 테스트")
+//    public void doubleRequestSend() throws InterruptedException {
+//        int numberOfThreads = 30;
+//        Set<String> set = new HashSet<>();
+//        ExecutorService service = Executors.newFixedThreadPool(numberOfThreads);
+//        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+//        for(int i=0; i<numberOfThreads; i++){
+//            service.execute(()->{
+//                ResponseEntity<ResponseDto> response = userAuthController.testLogin();
+//                UserLoginDto userLoginDto = (UserLoginDto)response.getBody().getData();
+//                set.add(userLoginDto.getEmail());
+//                latch.countDown();
+//            });
+//        }
+//        latch.await();
+//        assertEquals(numberOfThreads, set.size());
+//    }
+
+
+//    @Test
+//    public void deleteTestUser(){
+//        List<Long> testUsers = queryFactory
+//                .select(user.seq)
+//                .from(user)
+//                .where(user.socialType.eq(SDUTY))
+//                .fetch();
+//
+//        for(Long seq : testUsers){
+//            userAuthService.deleteUser(seq);
+//        }
+//    }
 
     private List<String> getLastUserID(){
         return queryFactory


### PR DESCRIPTION
## 개요
- 테스트 계정 생성 시 발생하는 동시성 문제 해결

## 변경 사항
test: 테스트 계정 | 테스트 계정 중복 생성 테스트 작성 ... 0f15e06154e416693a33989503132a7455557139
- thread 30개로 동시에 테스트 계정 생성을 요청하는 로직
- 계정을 생성하여 집합에 삽입 후, thread 즉 요청 개수와 일치하는지 확인함

refactor: 테스트 계정 | 테스트 계정 중복 생성 방지 ... adb581b60913853ea568958b124d9f9d5217b1a6
- 단일 서버로 synchronized를 사용하여 해결함
- transaction처리 로직도 synchronized범위에 포함하기 위해, service클래스 외부에 적용함 